### PR TITLE
Symlink post request

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -266,7 +266,7 @@ func updateSymlink(gitRoot, link, newDir string) error {
 
 	// If there is a symlink update callback, call it
 	if len(*flSymlinkUpdatePostUrl) > 0 {
-		log.V(0).Infof("sending post request to %s", *flSymlinkUpdatePostUrl)
+		log.V(1).Infof("sending post request to %s", *flSymlinkUpdatePostUrl)
 		// Send the post request
 		req, err := http.NewRequest("POST", *flSymlinkUpdatePostUrl, nil)
 		if err != nil {

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -32,7 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"http"
+	"net/http"
 
 	"github.com/thockin/glogr"
 	"github.com/thockin/logr"
@@ -264,6 +264,16 @@ func updateSymlink(gitRoot, link, newDir string) error {
 	}
 	log.V(1).Infof("renamed symlink %s to %s", "tmp-link", link)
 
+	// If there is a symlink update callback, call it
+	if len(*flSymlinkUpdatePostUrl) > 0 {
+		log.V(0).Infof("sending post request to %s", *flSymlinkUpdatePostUrl)
+		// Send the post request
+		_, err := http.NewRequest("POST", *flSymlinkUpdatePostUrl, nil)
+		if err != nil {
+			return fmt.Errorf("error sending symlink update callback post request: %v", err)
+		}
+	}
+
 	// Clean up previous worktree
 	if len(currentDir) > 0 {
 		if err = os.RemoveAll(currentDir); err != nil {
@@ -278,15 +288,6 @@ func updateSymlink(gitRoot, link, newDir string) error {
 		}
 
 		log.V(1).Infof("pruned old worktrees")
-	}
-	
-	// If there is a symlink update callback, call it
-	if len(*flSymlinkUpdateCallback) > 0 {
-		// Send the post request
-		resp, err := http.NewRequest("POST", url, nil)
-		if err != nil {
-			return fmt.Errorf("error sending symlink update callback post request: %v", err)
-		}
 	}
 
 	return nil

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -32,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"http"
 
 	"github.com/thockin/glogr"
 	"github.com/thockin/logr"
@@ -58,6 +59,8 @@ var flMaxSyncFailures = flag.Int("max-sync-failures", envInt("GIT_SYNC_MAX_SYNC_
 	"the number of consecutive failures allowed before aborting (the first pull must succeed)")
 var flChmod = flag.Int("change-permissions", envInt("GIT_SYNC_PERMISSIONS", 0),
 	"the file permissions to apply to the checked-out files")
+var flSymlinkUpdatePostUrl = flag.String("symlink-update-post-url", envString("GIT_SYNC_SYMLINK_UPDATE_POST_URL", ""),
+	"a command to run when the symlink is updated")
 
 var flUsername = flag.String("username", envString("GIT_SYNC_USERNAME", ""),
 	"the username to use")
@@ -275,6 +278,15 @@ func updateSymlink(gitRoot, link, newDir string) error {
 		}
 
 		log.V(1).Infof("pruned old worktrees")
+	}
+	
+	// If there is a symlink update callback, call it
+	if len(*flSymlinkUpdateCallback) > 0 {
+		// Send the post request
+		resp, err := http.NewRequest("POST", url, nil)
+		if err != nil {
+			return fmt.Errorf("error sending symlink update callback post request: %v", err)
+		}
 	}
 
 	return nil

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -268,10 +268,13 @@ func updateSymlink(gitRoot, link, newDir string) error {
 	if len(*flSymlinkUpdatePostUrl) > 0 {
 		log.V(0).Infof("sending post request to %s", *flSymlinkUpdatePostUrl)
 		// Send the post request
-		_, err := http.NewRequest("POST", *flSymlinkUpdatePostUrl, nil)
+		req, err := http.NewRequest("POST", *flSymlinkUpdatePostUrl, nil)
 		if err != nil {
-			return fmt.Errorf("error sending symlink update callback post request: %v", err)
+			fmt.Errorf("error sending post request (after symlink update): %v", err)
 		}
+		c := &http.Client{}
+		resp, err := c.Do(req)
+		resp.Body.Close()
 	}
 
 	// Clean up previous worktree


### PR DESCRIPTION
After the symlink is changed (meaning the files have been updated), git-sync sends a POST request to the configured url.

This is useful when using services such as Prometheus, where an action (like a POST request) is necessary in order to refresh configuration.